### PR TITLE
Update toc.yml

### DIFF
--- a/information/licensing/toc.yml
+++ b/information/licensing/toc.yml
@@ -2,5 +2,5 @@
   href: index.md
 - name: Core licensing
   href: core-licensing.md
-- name: User licensing
+- name: User types
   href: user-types.md


### PR DESCRIPTION
Changed the name from "User licensing" to "User types" in the left navigation panel. 

Another file is proposed for Sessions-based licensing. 

User types was a bit ambiguous.