### PR TITLE
Update toc.yml

### DIFF
--- a/information/licensing/toc.yml
+++ b/information/licensing/toc.yml
@@ -1,5 +1,7 @@
 - name: Overview
   href: index.md
+- name: Concurrent Sessions-Based Licensing
+  href: concurrent-sessions-based-licensing.md
 - name: Core licensing
   href: core-licensing.md
 - name: User types


### PR DESCRIPTION
Fixed a missing link to the "Concurrent Sessions-Based Licensing" Article. 

Added the article to the navigation panel.